### PR TITLE
Create MetadataWriters and delegate to them

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,5 +9,5 @@ Metrics/MethodLength:
   Max: 15
 
 Documentation:
-  enabled: false
+  Enabled: false
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,6 +8,6 @@ Metrics/LineLength:
 Metrics/MethodLength:
   Max: 15
 
-Rubocop/Style/Documentation:
+Style/Documentation:
   enabled: false
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,3 +7,7 @@ Metrics/LineLength:
   Max: 120
 Metrics/MethodLength:
   Max: 15
+
+Rubocop/Style/Documentation:
+  enabled: false
+

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,6 +8,6 @@ Metrics/LineLength:
 Metrics/MethodLength:
   Max: 15
 
-Style/Documentation:
+Documentation:
   enabled: false
 

--- a/app/models/song.rb
+++ b/app/models/song.rb
@@ -166,7 +166,7 @@ class Song
 
   def write_metadata_to_file!
     (Song::WRITABLE_FIELDS).each do |field_name|
-      AudioMetadata::write_tag(self.full_path, field_name, self.send(field_name))
+      AudioMetadata.new(self.full_path).write_tag(field_name, self.send(field_name))
     end
   end
 

--- a/app/models/song.rb
+++ b/app/models/song.rb
@@ -130,7 +130,7 @@ class Song
   # write new embedded cover art metadata. erase all previous art in this metadata.
   def write_cover_art_to_metadata!(file_type, cover_art_data)
     Rails.logger.info "--- Trying to write cover art metadata for song #{self.id} - #{self.title}."
-    AudioMetadata::write_cover_art_to_metadata!(self.full_path, cover_art_data, file_type)
+    AudioMetadata.new(self.full_path).write_cover_art_to_metadata!(cover_art_data, file_type)
   end
 
   def delete_source_file!

--- a/app/services/audio_metadata.rb
+++ b/app/services/audio_metadata.rb
@@ -54,34 +54,4 @@ class AudioMetadata
     existing_comment.match /\[PRIPHEA-ID-(.{24})\]/
     $1
   end
-
-  # if track number is stored in priphea db as "track_number", in mp3 id3v2 it's named "track".
-  # this method turns "track_number" into "track".
-
-  # some example of an id3v2 data set:
-  # - ["TIT2 Sea-Cat Walkway [Boy Meets Girl]", "TPE1 arc", "TRCK 1/0", "TALB Sea-Cat Walkway - Mother Arrange+Original Album", "TPOS 0/0", "TDRC 2006", "TCON 同ﾺ", "APIC [image/jpeg]", "POPM no@email rating=255 counter=0", "TBPM 0", "TCMP 0", "TDOR 0000", "TPE2 arc", "UFID ", "USLT "]
-  def self::rename_tag_from_priphea_to_metadata_name(priphea_tag_name, extension)
-    if extension == '.mp3'
-      case priphea_tag_name
-        when 'track_number'
-          'track'
-        when 'disc_number'
-          'TPOS' # part of set frame
-        when 'album_artist'
-          'TPE2'
-        when 'album_title'
-          'album'
-        else
-          priphea_tag_name
-      end
-    else
-      case priphea_tag_name
-        when 'album_title'
-          'album'
-        else
-          priphea_tag_name
-      end
-    end
-  end
-
 end

--- a/app/services/audio_metadata.rb
+++ b/app/services/audio_metadata.rb
@@ -3,17 +3,20 @@ require 'forwardable'
 class AudioMetadata
   extend Forwardable
 
+  attr_accessor :filename
+
   attr_accessor :metadata_writer
-  delegate [:write_cover_art_to_metadata!] => :metadata_writer
+  delegate [:write_cover_art_to_metadata!, :write_tag] => :metadata_writer
 
   def initialize(filename)
-    extension = File.extname(filename).downcase
+    @filename = String(filename)
+    extension = File.extname(@filename).downcase
 
     @metadata_writer = case extension
     when '.mp3'
-      Mp3MetadataWriter.new
+      Mp3MetadataWriter.new(@filename)
     when '.flac'
-      FlacMetadataWriter.new
+      FlacMetadataWriter.new(@filename)
     end
   end
 
@@ -24,14 +27,15 @@ class AudioMetadata
   def self.from_file(filename)
     file_extension = AudioMetadata::file_extension(filename)
 
-    extractor = case file_extension
+    extractor =
+      case file_extension
       when ".mp3"
         MetadataExtractors::Mp3MetadataExtractor.new(filename)
       when ".flac"
         MetadataExtractors::FlacMetadataExtractor.new(filename)
       else
         raise "Unsupported file type"
-   end
+      end
 
     metadata = extractor.create_metadata_hash
     metadata
@@ -49,67 +53,6 @@ class AudioMetadata
 
     existing_comment.match /\[PRIPHEA-ID-(.{24})\]/
     $1
-  end
-
-  # supported fields for writing:
-  # - title
-  # - artist
-  # - album_artist
-  # - track number
-  # - disc number
-  # - comment
-  # - album_title
-  def self.write_tag(filename, tag_name, data)
-    return false unless Song::WRITABLE_FIELDS.include? tag_name
-    file_extension = AudioMetadata::file_extension(filename)
-
-    tag_name = AudioMetadata::rename_tag_from_priphea_to_metadata_name(tag_name, file_extension)
-
-    if %w(.mp3).include?(file_extension)
-      TagLib::MPEG::File.open(filename) do |file|
-        tag = file.id3v2_tag(true)
-        case tag_name
-          when 'comment'
-            new_frame = true
-            if (frame = tag.frame_list('COMM').try(:first))
-              new_frame = false
-            end
-            frame ||= TagLib::ID3v2::CommentsFrame.new
-            frame.language = 'eng'
-            frame.text = data.to_s
-            frame.text_encoding = TagLib::String::UTF8
-            tag.add_frame(frame) if new_frame
-          when 'TPOS' # part of set / disc #
-            new_frame = true
-            if (frame = tag.frame_list('TPOS').try(:first))
-              new_frame = false
-            end
-            frame ||= TagLib::ID3v2::TextIdentificationFrame.new("TPOS", TagLib::String::UTF8)
-            frame.text = data.to_s
-            tag.add_frame(frame) if new_frame
-          when 'TPE2'
-            new_frame = true
-            if (frame = tag.frame_list('TPE2').try(:first))
-              new_frame = false
-            end
-            frame ||= TagLib::ID3v2::TextIdentificationFrame.new("TPE2", TagLib::String::UTF8)
-            frame.text = data.to_s
-            tag.add_frame(frame) if new_frame
-          else
-            tag.send(tag_name + "=", data)
-        end
-        file.save
-      end
-    elsif %w(.flac).include?(file_extension)
-      TagLib::FLAC::File.open(filename) do |file|
-        if %w{album artist comment genre title track year}.include?(tag_name)
-          file.xiph_comment.send(tag_name + "=", data.to_s)
-        else
-          file.xiph_comment.send(:add_field, tag_name, data.to_s)
-        end
-        file.save
-      end
-    end
   end
 
   # if track number is stored in priphea db as "track_number", in mp3 id3v2 it's named "track".

--- a/app/services/audio_metadata.rb
+++ b/app/services/audio_metadata.rb
@@ -24,7 +24,7 @@ class AudioMetadata
     File.extname(filename).downcase
   end
 
-  def self.from_file(filename)
+  def metadata_hash
     file_extension = AudioMetadata::file_extension(filename)
 
     extractor =

--- a/app/services/metadata_writers/flac_metadata_writer.rb
+++ b/app/services/metadata_writers/flac_metadata_writer.rb
@@ -3,16 +3,15 @@ class FlacMetadataWriter
   end
 
   def write_cover_art_to_metadata!(filename, cover_art_data, cover_art_file_type)
-    mime_type = if cover_art_file_type == '.jpg'
-      "image/jpeg"
-    elsif cover_art_file_type == ".png"
-      "image/png"
-    end
-
-    Rails.logger.info "--- Writing FLAC metadata."
+    mime_type =
+      if cover_art_file_type == '.jpg'
+        "image/jpeg"
+      elsif cover_art_file_type == ".png"
+        "image/png"
+      end
 
     TagLib::FLAC::File.open(filename) do |file|
-      file.remove_pictures # remove all pre-existing pictures.
+      file.remove_pictures
 
       pic = TagLib::FLAC::Picture.new
       pic.type = TagLib::FLAC::Picture::FrontCover

--- a/app/services/metadata_writers/flac_metadata_writer.rb
+++ b/app/services/metadata_writers/flac_metadata_writer.rb
@@ -1,0 +1,27 @@
+class FlacMetadataWriter
+  def initialize
+  end
+
+  def write_cover_art_to_metadata!(filename, cover_art_data, cover_art_file_type)
+    mime_type = if cover_art_file_type == '.jpg'
+      "image/jpeg"
+    elsif cover_art_file_type == ".png"
+      "image/png"
+    end
+
+    Rails.logger.info "--- Writing FLAC metadata."
+
+    TagLib::FLAC::File.open(filename) do |file|
+      file.remove_pictures # remove all pre-existing pictures.
+
+      pic = TagLib::FLAC::Picture.new
+      pic.type = TagLib::FLAC::Picture::FrontCover
+      pic.mime_type = mime_type
+      pic.description = "Cover"
+      pic.data = cover_art_data
+
+      file.add_picture(pic)
+      file.save
+    end
+  end
+end

--- a/app/services/metadata_writers/flac_metadata_writer.rb
+++ b/app/services/metadata_writers/flac_metadata_writer.rb
@@ -5,7 +5,7 @@ class FlacMetadataWriter
     @filename = String(filename)
   end
 
-  def write_cover_art_to_metadata!(filename, cover_art_data, cover_art_file_type)
+  def write_cover_art_to_metadata!(cover_art_data, cover_art_file_type)
     mime_type =
       if cover_art_file_type == '.jpg'
         "image/jpeg"
@@ -13,7 +13,7 @@ class FlacMetadataWriter
         "image/png"
       end
 
-    TagLib::FLAC::File.open(filename) do |file|
+    TagLib::FLAC::File.open(@filename) do |file|
       file.remove_pictures
 
       pic = TagLib::FLAC::Picture.new
@@ -33,7 +33,7 @@ class FlacMetadataWriter
     tag_name = rename_tag_from_priphea_to_metadata_name(tag_name)
 
     TagLib::FLAC::File.open(@filename) do |file|
-      if %w{album artist comment genre title track year}.include?(tag_name)
+      if %w(album artist comment genre title track year).include?(tag_name)
         file.xiph_comment.send(tag_name + "=", data.to_s)
       else
         file.xiph_comment.send(:add_field, tag_name, data.to_s)

--- a/app/services/metadata_writers/flac_metadata_writer.rb
+++ b/app/services/metadata_writers/flac_metadata_writer.rb
@@ -5,13 +5,16 @@ class FlacMetadataWriter
     @filename = String(filename)
   end
 
+  def determine_image_format_mime_type(image_file_type)
+    if image_file_type == '.jpg'
+      "image/jpeg"
+    elsif image_file_type == ".png"
+      "image/png"
+    end
+  end
+
   def write_cover_art_to_metadata!(cover_art_data, cover_art_file_type)
-    mime_type =
-      if cover_art_file_type == '.jpg'
-        "image/jpeg"
-      elsif cover_art_file_type == ".png"
-        "image/png"
-      end
+    mime_type = determine_image_format_mime_type(cover_art_file_type)
 
     TagLib::FLAC::File.open(@filename) do |file|
       file.remove_pictures

--- a/app/services/metadata_writers/flac_metadata_writer.rb
+++ b/app/services/metadata_writers/flac_metadata_writer.rb
@@ -29,9 +29,8 @@ class FlacMetadataWriter
 
   def write_tag(tag_name, data)
     return false unless Song::WRITABLE_FIELDS.include? tag_name
-    file_extension = AudioMetadata::file_extension(@filename)
 
-    tag_name = AudioMetadata::rename_tag_from_priphea_to_metadata_name(tag_name, file_extension)
+    tag_name = rename_tag_from_priphea_to_metadata_name(tag_name)
 
     TagLib::FLAC::File.open(@filename) do |file|
       if %w{album artist comment genre title track year}.include?(tag_name)
@@ -40,6 +39,15 @@ class FlacMetadataWriter
         file.xiph_comment.send(:add_field, tag_name, data.to_s)
       end
       file.save
+    end
+  end
+
+  def rename_tag_from_priphea_to_metadata_name(priphea_tag_name)
+    case priphea_tag_name
+    when 'album_title'
+      'album'
+    else
+      priphea_tag_name
     end
   end
 end

--- a/app/services/metadata_writers/flac_metadata_writer.rb
+++ b/app/services/metadata_writers/flac_metadata_writer.rb
@@ -1,5 +1,8 @@
 class FlacMetadataWriter
-  def initialize
+  attr_accessor :filename
+
+  def initialize(filename)
+    @filename = String(filename)
   end
 
   def write_cover_art_to_metadata!(filename, cover_art_data, cover_art_file_type)
@@ -20,6 +23,22 @@ class FlacMetadataWriter
       pic.data = cover_art_data
 
       file.add_picture(pic)
+      file.save
+    end
+  end
+
+  def write_tag(tag_name, data)
+    return false unless Song::WRITABLE_FIELDS.include? tag_name
+    file_extension = AudioMetadata::file_extension(@filename)
+
+    tag_name = AudioMetadata::rename_tag_from_priphea_to_metadata_name(tag_name, file_extension)
+
+    TagLib::FLAC::File.open(@filename) do |file|
+      if %w{album artist comment genre title track year}.include?(tag_name)
+        file.xiph_comment.send(tag_name + "=", data.to_s)
+      else
+        file.xiph_comment.send(:add_field, tag_name, data.to_s)
+      end
       file.save
     end
   end

--- a/app/services/metadata_writers/mp3_metadata_writer.rb
+++ b/app/services/metadata_writers/mp3_metadata_writer.rb
@@ -1,0 +1,36 @@
+class Mp3MetadataWriter
+  def initialize
+  end
+
+  def write_cover_art_to_metadata!(filename, cover_art_data, cover_art_file_type)
+    mime_type = if cover_art_file_type == '.jpg'
+      "image/jpeg"
+    elsif cover_art_file_type == ".png"
+      "image/png"
+    end
+
+    Rails.logger.info "--- Writing MP3 metadata."
+
+    TagLib::MPEG::File.open(filename) do |file|
+      tag = file.id3v2_tag
+
+      # Remove pre-existing art
+      tag.frame_list('APIC').each do |frame|
+        tag.remove_frame(frame)
+      end
+
+      file.save
+
+      # Add attached picture frame
+      apic = TagLib::ID3v2::AttachedPictureFrame.new
+      apic.mime_type = mime_type
+      apic.description = "Cover"
+      apic.type = TagLib::ID3v2::AttachedPictureFrame::FrontCover
+      apic.picture = cover_art_data
+
+      tag.add_frame(apic)
+
+      file.save
+    end
+  end
+end

--- a/app/services/metadata_writers/mp3_metadata_writer.rb
+++ b/app/services/metadata_writers/mp3_metadata_writer.rb
@@ -3,13 +3,12 @@ class Mp3MetadataWriter
   end
 
   def write_cover_art_to_metadata!(filename, cover_art_data, cover_art_file_type)
-    mime_type = if cover_art_file_type == '.jpg'
-      "image/jpeg"
-    elsif cover_art_file_type == ".png"
-      "image/png"
-    end
-
-    Rails.logger.info "--- Writing MP3 metadata."
+    mime_type =
+      if cover_art_file_type == '.jpg'
+        "image/jpeg"
+      elsif cover_art_file_type == ".png"
+        "image/png"
+      end
 
     TagLib::MPEG::File.open(filename) do |file|
       tag = file.id3v2_tag

--- a/app/services/metadata_writers/mp3_metadata_writer.rb
+++ b/app/services/metadata_writers/mp3_metadata_writer.rb
@@ -5,13 +5,16 @@ class Mp3MetadataWriter
     @filename = String(filename)
   end
 
+  def determine_image_format_mime_type(image_file_type)
+    if image_file_type == '.jpg'
+      "image/jpeg"
+    elsif image_file_type == ".png"
+      "image/png"
+    end
+  end
+
   def write_cover_art_to_metadata!(cover_art_data, cover_art_file_type)
-    mime_type =
-      if cover_art_file_type == '.jpg'
-        "image/jpeg"
-      elsif cover_art_file_type == ".png"
-        "image/png"
-      end
+    mime_type = determine_image_format_mime_type(cover_art_file_type)
 
     TagLib::MPEG::File.open(@filename) do |file|
       tag = file.id3v2_tag

--- a/app/services/metadata_writers/mp3_metadata_writer.rb
+++ b/app/services/metadata_writers/mp3_metadata_writer.rb
@@ -5,7 +5,7 @@ class Mp3MetadataWriter
     @filename = String(filename)
   end
 
-  def write_cover_art_to_metadata!(filename, cover_art_data, cover_art_file_type)
+  def write_cover_art_to_metadata!(cover_art_data, cover_art_file_type)
     mime_type =
       if cover_art_file_type == '.jpg'
         "image/jpeg"
@@ -13,7 +13,7 @@ class Mp3MetadataWriter
         "image/png"
       end
 
-    TagLib::MPEG::File.open(filename) do |file|
+    TagLib::MPEG::File.open(@filename) do |file|
       tag = file.id3v2_tag
 
       # Remove pre-existing art

--- a/app/services/metadata_writers/mp3_metadata_writer.rb
+++ b/app/services/metadata_writers/mp3_metadata_writer.rb
@@ -38,9 +38,8 @@ class Mp3MetadataWriter
 
   def write_tag(tag_name, data)
     return false unless Song::WRITABLE_FIELDS.include? tag_name
-    file_extension = AudioMetadata::file_extension(@filename)
 
-    tag_name = AudioMetadata::rename_tag_from_priphea_to_metadata_name(tag_name, file_extension)
+    tag_name = rename_tag_from_priphea_to_metadata_name(tag_name)
 
     TagLib::MPEG::File.open(@filename) do |file|
       tag = file.id3v2_tag(true)
@@ -75,6 +74,21 @@ class Mp3MetadataWriter
         tag.send(tag_name + "=", data)
       end
       file.save
+    end
+  end
+
+  def rename_tag_from_priphea_to_metadata_name(priphea_tag_name)
+    case priphea_tag_name
+    when 'track_number'
+      'track'
+    when 'disc_number'
+      'TPOS' # part of set frame
+    when 'album_artist'
+      'TPE2'
+    when 'album_title'
+      'album'
+    else
+      priphea_tag_name
     end
   end
 end

--- a/app/services/metadata_writers/mp3_metadata_writer.rb
+++ b/app/services/metadata_writers/mp3_metadata_writer.rb
@@ -1,5 +1,8 @@
 class Mp3MetadataWriter
-  def initialize
+  attr_accessor :filename
+
+  def initialize(filename)
+    @filename = String(filename)
   end
 
   def write_cover_art_to_metadata!(filename, cover_art_data, cover_art_file_type)
@@ -29,6 +32,48 @@ class Mp3MetadataWriter
 
       tag.add_frame(apic)
 
+      file.save
+    end
+  end
+
+  def write_tag(tag_name, data)
+    return false unless Song::WRITABLE_FIELDS.include? tag_name
+    file_extension = AudioMetadata::file_extension(@filename)
+
+    tag_name = AudioMetadata::rename_tag_from_priphea_to_metadata_name(tag_name, file_extension)
+
+    TagLib::MPEG::File.open(@filename) do |file|
+      tag = file.id3v2_tag(true)
+      case tag_name
+      when 'comment'
+        new_frame = true
+        if (frame = tag.frame_list('COMM').try(:first))
+          new_frame = false
+        end
+        frame ||= TagLib::ID3v2::CommentsFrame.new
+        frame.language = 'eng'
+        frame.text = data.to_s
+        frame.text_encoding = TagLib::String::UTF8
+        tag.add_frame(frame) if new_frame
+      when 'TPOS' # part of set / disc #
+        new_frame = true
+        if (frame = tag.frame_list('TPOS').try(:first))
+          new_frame = false
+        end
+        frame ||= TagLib::ID3v2::TextIdentificationFrame.new("TPOS", TagLib::String::UTF8)
+        frame.text = data.to_s
+        tag.add_frame(frame) if new_frame
+      when 'TPE2'
+        new_frame = true
+        if (frame = tag.frame_list('TPE2').try(:first))
+          new_frame = false
+        end
+        frame ||= TagLib::ID3v2::TextIdentificationFrame.new("TPE2", TagLib::String::UTF8)
+        frame.text = data.to_s
+        tag.add_frame(frame) if new_frame
+      else
+        tag.send(tag_name + "=", data)
+      end
       file.save
     end
   end

--- a/app/services/song_scanner.rb
+++ b/app/services/song_scanner.rb
@@ -53,7 +53,7 @@ class SongScanner
   end
 
   def load_metadata_from_file_into_hash
-    @metadata ||= AudioMetadata.from_file(@filename)
+    @metadata ||= AudioMetadata.new(@filename).metadata_hash
   end
 
   def write_priphea_id_to_file_metadata

--- a/app/services/song_scanner.rb
+++ b/app/services/song_scanner.rb
@@ -58,7 +58,7 @@ class SongScanner
 
   def write_priphea_id_to_file_metadata
     @metadata['comment'] = AudioMetadata.generate_priphea_id_comment(@metadata['comment'], @song)
-    AudioMetadata::write_tag(@filename, "comment", @metadata['comment'])
+    AudioMetadata.new(@filename).write_tag("comment", @metadata['comment'])
   end
 
   def load_file_metadata_into_song_record

--- a/spec/services/audio_metadata_spec.rb
+++ b/spec/services/audio_metadata_spec.rb
@@ -138,7 +138,7 @@ describe AudioMetadata, file_cleaning: :full do
 
       it "should be able to write a short comment" do
         short_string = "short"
-        AudioMetadata::write_tag(file, "comment", short_string)
+        AudioMetadata.new(file).write_tag("comment", short_string)
 
         actual_metadata_comment = AudioMetadata::from_file(file)['comment']
         expect(actual_metadata_comment).to eq(short_string)
@@ -146,7 +146,7 @@ describe AudioMetadata, file_cleaning: :full do
 
       it "should be able to write long comment" do
         long_string = "[BLAH-BLAH-8043782047u2fjeauf892u89rhfe89]"
-        AudioMetadata::write_tag(file, "comment", long_string)
+        AudioMetadata.new(file).write_tag("comment", long_string)
 
         actual_metadata_comment = AudioMetadata::from_file(file)['comment']
         expect(actual_metadata_comment).to eq(long_string)

--- a/spec/services/audio_metadata_spec.rb
+++ b/spec/services/audio_metadata_spec.rb
@@ -140,7 +140,7 @@ describe AudioMetadata, file_cleaning: :full do
         short_string = "short"
         AudioMetadata.new(file).write_tag("comment", short_string)
 
-        actual_metadata_comment = AudioMetadata::from_file(file)['comment']
+        actual_metadata_comment = AudioMetadata.new(file).metadata_hash['comment']
         expect(actual_metadata_comment).to eq(short_string)
       end
 
@@ -148,7 +148,7 @@ describe AudioMetadata, file_cleaning: :full do
         long_string = "[BLAH-BLAH-8043782047u2fjeauf892u89rhfe89]"
         AudioMetadata.new(file).write_tag("comment", long_string)
 
-        actual_metadata_comment = AudioMetadata::from_file(file)['comment']
+        actual_metadata_comment = AudioMetadata.new(file).metadata_hash['comment']
         expect(actual_metadata_comment).to eq(long_string)
       end
 
@@ -173,7 +173,7 @@ describe AudioMetadata, file_cleaning: :full do
 
         expect(@song.write_metadata_to_file!).to be_truthy
 
-        metadata = AudioMetadata::from_file(@song.full_path)
+        metadata = AudioMetadata.new(@song.full_path).metadata_hash
         expect(metadata['title']).to eq(new_title)
         expect(metadata['comment']).to eq(new_comment)
         expect(metadata['track_number']).to eq(new_track_number)

--- a/spec/services/audio_metadata_spec.rb
+++ b/spec/services/audio_metadata_spec.rb
@@ -196,34 +196,4 @@ describe AudioMetadata, file_cleaning: :full do
       end
     end
   end
-
-  describe ".rename_tag_from_priphea_to_metadata_name" do
-    it "handles same-name case" do
-      result = AudioMetadata::rename_tag_from_priphea_to_metadata_name("comment", @ext)
-      expect(result).to eq("comment")
-    end
-
-    context "MP3" do
-      before { @ext = ".mp3" }
-
-      it "track_number" do
-        result = AudioMetadata::rename_tag_from_priphea_to_metadata_name("track_number", @ext)
-        expect(result).to eq("track")
-      end
-
-      it "disc_number" do
-        result = AudioMetadata::rename_tag_from_priphea_to_metadata_name("disc_number", @ext)
-        expect(result).to eq("TPOS")
-      end
-
-      it "album_artist" do
-        result = AudioMetadata::rename_tag_from_priphea_to_metadata_name("album_artist", @ext)
-        expect(result).to eq("TPE2")
-      end
-    end
-
-    context "FLAC" do
-      before { @ext = ".flac" }
-    end
-  end
 end

--- a/spec/services/library_scanner_spec.rb
+++ b/spec/services/library_scanner_spec.rb
@@ -124,7 +124,7 @@ describe LibraryScanner, file_cleaning: :full do
 
       # need to change song title in metadata, then reimport it
       title_after = "TestTitle_#{Random.rand(100000)}"
-      AudioMetadata::write_tag(song.full_path, "title", title_after)
+      AudioMetadata.new(song.full_path).write_tag("title", title_after)
 
       @scanner.scan
 

--- a/spec/services/metadata_writers/flac_metadata_writer_spec.rb
+++ b/spec/services/metadata_writers/flac_metadata_writer_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+describe FlacMetadataWriter do
+  describe ".rename_tag_from_priphea_to_metadata_name" do
+    let!(:writer) { FlacMetadataWriter.new("filename.flac") }
+
+    it "handles same-name case" do
+      result = writer.rename_tag_from_priphea_to_metadata_name("comment")
+      expect(result).to eq("comment")
+    end
+
+    it "renames album title" do
+      result = writer.rename_tag_from_priphea_to_metadata_name("album_title")
+      expect(result).to eq("album")
+    end
+  end
+end

--- a/spec/services/metadata_writers/mp3_metadata_writer_spec.rb
+++ b/spec/services/metadata_writers/mp3_metadata_writer_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+describe Mp3MetadataWriter do
+  describe ".rename_tag_from_priphea_to_metadata_name" do
+    let!(:writer) { Mp3MetadataWriter.new("filename.mp3") }
+
+    it "handles same-name case" do
+      result = writer.rename_tag_from_priphea_to_metadata_name("comment")
+      expect(result).to eq("comment")
+    end
+
+    it "track_number" do
+      result = writer.rename_tag_from_priphea_to_metadata_name("track_number")
+      expect(result).to eq("track")
+    end
+
+    it "disc_number" do
+      result = writer.rename_tag_from_priphea_to_metadata_name("disc_number")
+      expect(result).to eq("TPOS")
+    end
+
+    it "album_artist" do
+      result = writer.rename_tag_from_priphea_to_metadata_name("album_artist")
+      expect(result).to eq("TPE2")
+    end
+  end
+end


### PR DESCRIPTION
AudioMetadata contains several methods that
have conditions on mp3/flac, and then do
different logic for writing these fields.

I’m moving this logic into Mp3MetadataWriter
and FlacMetadataWriter, then delegating methods
to them using ruby’s Forwardable.